### PR TITLE
fix(docker): add curl for healthcheck support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ WORKDIR /app
 # System deps (only what we actually need runtime + build for psycopg if used later)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
+    curl \
     libpq-dev \
     postgresql-client \
     && rm -rf /var/lib/apt/lists/*
@@ -91,8 +92,9 @@ WORKDIR /app
 
 # Only runtime system deps (no build-essential)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    postgresql-client \
+    curl \
     libpq5 \
+    postgresql-client \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy installed site-packages from base (dependencies) to slim runtime


### PR DESCRIPTION
## Summary

Adds `curl` to the Docker image to fix healthcheck failures during container startup.

## Problem

The Storage service Docker healthcheck was failing because `curl` is not installed in the Python base image. This caused:

- Healthcheck failures for 10 retries × 5 seconds = **50 seconds delay** before marking container as healthy
- Error: `exec: "curl": executable file not found in $PATH`
- Slower integration test startup
- Poor developer experience during local testing

## Solution

Added `curl` to both `base` and `production` stages in the Dockerfile:

```dockerfile
RUN apt-get update && apt-get install -y --no-install-recommends \
    build-essential \
    curl \
    libpq-dev \
    postgresql-client \
    && rm -rf /var/lib/apt/lists/*
```

## Changes

- ✅ Added `curl` to base stage (development & test)
- ✅ Added `curl` to production stage
- ✅ Packages sorted alphabetically (linter requirement)
- ✅ Minimal image size impact (~2-3MB)

## Impact

- **Faster startup**: Healthcheck passes in ~5-10 seconds instead of 50 seconds
- **Better DX**: Local development containers start faster
- **Reliable CI/CD**: Integration tests start without delays
- **Standard practice**: Using curl for healthchecks is industry standard

## Testing

Healthcheck command (existing in docker-compose files):

```yaml
healthcheck:
  test: ["CMD", "curl", "-f", "http://localhost:5000/health"]
  interval: 5s
  timeout: 3s
  retries: 10
```

Will now succeed immediately when the Flask app is ready.

## Type of Change

- [x] Bug fix (non-breaking change)
- [x] Improves developer experience
- [x] Reduces CI/CD time
- [ ] No database migration required
- [ ] No configuration changes required

Closes #10